### PR TITLE
Add a StashClient with BasicAuth support

### DIFF
--- a/src/main/scala/com/codacy/client/stash/client/auth/Authenticator.scala
+++ b/src/main/scala/com/codacy/client/stash/client/auth/Authenticator.scala
@@ -1,0 +1,7 @@
+package com.codacy.client.stash.client.auth
+
+import play.api.libs.ws.WSRequest
+
+trait Authenticator {
+  def withAuthentication(request: WSRequest): WSRequest
+}

--- a/src/main/scala/com/codacy/client/stash/client/auth/BasicAuthenticator.scala
+++ b/src/main/scala/com/codacy/client/stash/client/auth/BasicAuthenticator.scala
@@ -1,0 +1,6 @@
+package com.codacy.client.stash.client.auth
+import play.api.libs.ws.{WSAuthScheme, WSRequest}
+
+class BasicAuthenticator(username: String, password: String) extends Authenticator {
+  override def withAuthentication(request: WSRequest) = request.withAuth(username, password, WSAuthScheme.BASIC)
+}

--- a/src/main/scala/com/codacy/client/stash/client/auth/OAuth1Authenticator.scala
+++ b/src/main/scala/com/codacy/client/stash/client/auth/OAuth1Authenticator.scala
@@ -1,0 +1,12 @@
+package com.codacy.client.stash.client.auth
+import com.ning.http.client.oauth.{ConsumerKey, RequestToken}
+import play.api.libs.ws.WSRequest
+
+class OAuth1Authenticator(key: String, secretKey: String, token: String, secretToken: String) extends Authenticator {
+  private lazy val KEY = new ConsumerKey(key, secretKey)
+  private lazy val TOKEN = new RequestToken(token, secretToken)
+
+  private lazy val requestSigner = new WSSignatureCalculatorRSA(KEY, TOKEN)
+
+  override def withAuthentication(request: WSRequest): WSRequest = request.sign(requestSigner)
+}


### PR DESCRIPTION
Changes:
+ `StashBasicAuthClient` to support http basic auth
+ `StashClientBase` serves as the base class of any clients
+ The default `StashClient` for oauth is not renamed for backward compatibility

Test:
* Tested on my local machine with both username/password, username/personal access token