### PR TITLE
Make email optional - FT-6391

### DIFF
--- a/src/main/scala/com/codacy/client/stash/User.scala
+++ b/src/main/scala/com/codacy/client/stash/User.scala
@@ -3,12 +3,12 @@ package com.codacy.client.stash
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-case class User(username: String, email: String, displayName: String, authorId: Long)
+case class User(username: String, email: Option[String], displayName: String, authorId: Long)
 
 object User {
   implicit val reader: Reads[User] = (
     (__ \ "slug").read[String] and
-      (__ \ "emailAddress").read[String] and
+      (__ \ "emailAddress").readNullable[String] and
       (__ \ "displayName").read[String] and
       (__ \ "id").read[Long]
     ) (User.apply _)


### PR DESCRIPTION
Parsing on User would fail if the user had no email.
This allows the emailAddress parameter to be optional.