### PR TITLE
fix: Follow redirects CY-822

### DIFF
--- a/src/main/scala/com/codacy/client/stash/util/HTTPStatusCodes.scala
+++ b/src/main/scala/com/codacy/client/stash/util/HTTPStatusCodes.scala
@@ -8,4 +8,15 @@ object HTTPStatusCodes {
   val UNAUTHORIZED = 401
   val FORBIDDEN = 403
   val NOT_FOUND = 404
+
+  //Redirects
+  object Redirects {
+    val MOVED_PERMANENTLY = 301
+    val FOUND = 302
+    val SEE_OTHER = 303
+    val TEMPORARY_REDIRECT = 307
+    val PERMANENT_REDIRECT = 308
+
+    val all = Seq(MOVED_PERMANENTLY, FOUND, SEE_OTHER, TEMPORARY_REDIRECT, PERMANENT_REDIRECT)
+  }
 }


### PR DESCRIPTION
Starts following redirects manually on http requests to
since we need to generate a new OAuth1 signature for new requests.