### PR TITLE
breaking: Fixes and cleaning on some endpoints

### DIFF
--- a/src/main/scala/com/codacy/client/stash/client/StashClient.scala
+++ b/src/main/scala/com/codacy/client/stash/client/StashClient.scala
@@ -15,8 +15,10 @@ class StashClient(apiUrl: String, authenticator: Option[Authenticator] = None, a
   /*
    * Does an API request and parses the json output into a class
    */
-  def execute[T](request: Request[T])(implicit reader: Reads[T]): RequestResponse[T] = {
-    get[T](request.path) match {
+  def execute[T](
+      request: Request[T]
+  )(params: Map[String, String] = Map.empty)(implicit reader: Reads[T]): RequestResponse[T] = {
+    get[T](request.path, params) match {
       case Right(json) => RequestResponse(json.asOpt[T])
       case Left(error) => error
     }
@@ -105,8 +107,8 @@ class StashClient(apiUrl: String, authenticator: Option[Authenticator] = None, a
     }
   }
 
-  def delete(requestUrl: String): RequestResponse[Boolean] = {
-    doRequest[Boolean](requestUrl, "DELETE", Map.empty, None) match {
+  def delete(requestUrl: String)(params: Map[String, String] = Map.empty): RequestResponse[Boolean] = {
+    doRequest[Boolean](requestUrl, "DELETE", params, None) match {
       case Right((HTTPStatusCodes.NO_CONTENT, _)) =>
         RequestResponse[Boolean](Option(true))
 

--- a/src/main/scala/com/codacy/client/stash/service/AdminServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/AdminServices.scala
@@ -17,19 +17,20 @@ class AdminServices(client: StashClient) {
       filter: Option[String],
       pageRequest: Option[PageRequest]
   ): RequestResponse[Seq[User]] = {
-    val parameters = Map("context" -> context, "filter" -> filter.getOrElse(""))
-    val filterField = filter.map(value => s"&filter=$value").getOrElse("")
+    val baseParameters = Map("context" -> context)
+
+    val parameters = filter.fold(baseParameters) { filter =>
+      baseParameters + ("filter" -> filter)
+    }
 
     pageRequest match {
       case Some(pageRequest) =>
         client.executePaginatedWithPageRequest(
-          Request(s"$BASE/groups/more-members?context=$context$filterField", classOf[Seq[User]]),
+          Request(s"$BASE/groups/more-members", classOf[Seq[User]]),
           pageRequest = pageRequest
         )(params = parameters)
       case None =>
-        client.executePaginated(Request(s"$BASE/groups/more-members?context=$context$filterField", classOf[Seq[User]]))(
-          params = parameters
-        )
+        client.executePaginated(Request(s"$BASE/groups/more-members", classOf[Seq[User]]))(params = parameters)
     }
   }
 }

--- a/src/main/scala/com/codacy/client/stash/service/ProjectServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/ProjectServices.scala
@@ -120,14 +120,4 @@ class ProjectServices(client: StashClient) {
         )()
       case None => client.executePaginated(Request(s"$BASE/$projectKey/permissions/groups", classOf[Seq[Group]]))()
     }
-
-  /**
-    * Retrieve the avatar for the project matching the supplied projectKey.
-    *
-    * The authenticated user must have PROJECT_VIEW permission for the specified project to call this resource.
-    */
-  def findAvatar(projectKey: String, size: Option[Int]): RequestResponse[String] = {
-    client.execute(Request(s"$BASE/$projectKey/avatar?${size.getOrElse(0)}", classOf[String]))
-  }
-
 }

--- a/src/main/scala/com/codacy/client/stash/service/ProjectServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/ProjectServices.scala
@@ -11,7 +11,7 @@ class ProjectServices(client: StashClient) {
     * Only projects for which the authenticated user has the PROJECT_VIEW permission will be returned.
     */
   def findById(projectKey: String): RequestResponse[Project] = {
-    client.execute(Request(s"$BASE/$projectKey", classOf[Project]))
+    client.execute(Request(s"$BASE/$projectKey", classOf[Project]))()
   }
 
   /**
@@ -32,16 +32,20 @@ class ProjectServices(client: StashClient) {
       projectKey: String,
       user: String,
       pageRequest: Option[PageRequest]
-  ): RequestResponse[Seq[UserPermission]] = pageRequest match {
-    case Some(pageRequest) =>
-      client.executePaginatedWithPageRequest(
-        Request(s"$BASE/$projectKey/permissions/users?filter=$user", classOf[Seq[UserPermission]]),
-        pageRequest = pageRequest
-      )()
-    case None =>
-      client.executePaginated(
-        Request(s"$BASE/$projectKey/permissions/users?filter=$user", classOf[Seq[UserPermission]])
-      )()
+  ): RequestResponse[Seq[UserPermission]] = {
+    val parameters = Map("filter" -> user)
+
+    pageRequest match {
+      case Some(pageRequest) =>
+        client.executePaginatedWithPageRequest(
+          Request(s"$BASE/$projectKey/permissions/users", classOf[Seq[UserPermission]]),
+          pageRequest = pageRequest
+        )(params = parameters)
+      case None =>
+        client.executePaginated(Request(s"$BASE/$projectKey/permissions/users", classOf[Seq[UserPermission]]))(
+          params = parameters
+        )
+    }
   }
 
   /**
@@ -88,22 +92,20 @@ class ProjectServices(client: StashClient) {
       projectKey: String,
       avatarSize: Option[Int],
       pageRequest: Option[PageRequest]
-  ): RequestResponse[Seq[UserPermission]] = pageRequest match {
-    case Some(pageRequest) =>
-      client.executePaginatedWithPageRequest(
-        Request(
-          s"$BASE/$projectKey/permissions/users?avatarSize=${avatarSize.getOrElse(0)}",
-          classOf[Seq[UserPermission]]
-        ),
-        pageRequest
-      )()
-    case None =>
-      client.executePaginated(
-        Request(
-          s"$BASE/$projectKey/permissions/users?avatarSize=${avatarSize.getOrElse(0)}",
-          classOf[Seq[UserPermission]]
+  ): RequestResponse[Seq[UserPermission]] = {
+    val parameters = Map("avatarSize" -> avatarSize.getOrElse(64).toString)
+
+    pageRequest match {
+      case Some(pageRequest) =>
+        client.executePaginatedWithPageRequest(
+          Request(s"$BASE/$projectKey/permissions/users", classOf[Seq[UserPermission]]),
+          pageRequest
+        )(params = parameters)
+      case None =>
+        client.executePaginated(Request(s"$BASE/$projectKey/permissions/users", classOf[Seq[UserPermission]]))(
+          params = parameters
         )
-      )()
+    }
   }
 
   /**

--- a/src/main/scala/com/codacy/client/stash/service/PullRequestServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/PullRequestServices.scala
@@ -25,7 +25,7 @@ class PullRequestServices(client: StashClient) {
     val stateParam = "state"
     val orderParam = "order"
     val url =
-      s"/rest/api/1.0/projects/$projectKey/repos/$repository/pull-requests?$directionParam=$direction&$stateParam=$state&$orderParam=$order"
+      s"/rest/api/1.0/projects/$projectKey/repos/$repository/pull-requests"
 
     client.executePaginated(Request(url, classOf[Seq[PullRequest]]))(
       Map(directionParam -> direction, stateParam -> state, orderParam -> order)
@@ -85,9 +85,9 @@ class PullRequestServices(client: StashClient) {
    * Delete a comment in a pull request
    */
   def deleteComment(projectKey: String, repo: String, prId: Long, commentId: Long): RequestResponse[Boolean] = {
-    val url = s"/rest/api/1.0/projects/$projectKey/repos/$repo/pull-requests/$prId/comments/$commentId?version=0"
+    val url = s"/rest/api/1.0/projects/$projectKey/repos/$repo/pull-requests/$prId/comments/$commentId"
 
-    client.delete(url)
+    client.delete(url)(Map("version" -> "0"))
   }
 
   def getPullRequestsReviewers(
@@ -97,6 +97,6 @@ class PullRequestServices(client: StashClient) {
   ): RequestResponse[PullRequestReviewers] = {
     val url = s"/rest/api/1.0/projects/$projectKey/repos/$repository/pull-requests/$prId"
 
-    client.execute(Request(url, classOf[PullRequestReviewers]))
+    client.execute(Request(url, classOf[PullRequestReviewers]))()
   }
 }

--- a/src/main/scala/com/codacy/client/stash/service/RepositoryServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/RepositoryServices.scala
@@ -153,7 +153,7 @@ class RepositoryServices(client: StashClient) {
       key: String,
       permission: String = "REPO_READ"
   ): RequestResponse[SshKeySimple] = {
-    val url = s"$BASE/$projectKey/repos/$repo/ssh"
+    val url = s"/rest/keys/1.0/projects/$projectKey/repos/$repo/ssh"
     val values = Json.obj("key" -> Json.obj("text" -> key), "permission" -> permission)
 
     client.postJson(Request(url, classOf[SshKeySimple]), values)

--- a/src/main/scala/com/codacy/client/stash/service/RepositoryServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/RepositoryServices.scala
@@ -28,7 +28,7 @@ class RepositoryServices(client: StashClient) {
     * The authenticated user must have REPO_READ permission for the specified repository to call this resource.
     */
   def getRepository(projectKey: String, repositorySlug: String): RequestResponse[Repository] = {
-    client.execute(Request(s"$BASE/$projectKey/repos/$repositorySlug", classOf[Repository]))
+    client.execute(Request(s"$BASE/$projectKey/repos/$repositorySlug", classOf[Repository]))()
   }
 
   /**
@@ -107,18 +107,12 @@ class RepositoryServices(client: StashClient) {
     pageRequest match {
       case Some(pageRequest) =>
         client.executePaginatedWithPageRequest(
-          Request(
-            s"$BASE/$projectKey/repos/$repositorySlug/permissions/users?filter=$user",
-            classOf[Seq[UserPermission]]
-          ),
+          Request(s"$BASE/$projectKey/repos/$repositorySlug/permissions/users", classOf[Seq[UserPermission]]),
           pageRequest = pageRequest
         )(params = filterParam)
       case None =>
         client.executePaginated(
-          Request(
-            s"$BASE/$projectKey/repos/$repositorySlug/permissions/users?filter=$user",
-            classOf[Seq[UserPermission]]
-          )
+          Request(s"$BASE/$projectKey/repos/$repositorySlug/permissions/users", classOf[Seq[UserPermission]])
         )(params = filterParam)
     }
   }

--- a/src/main/scala/com/codacy/client/stash/service/UserServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/UserServices.scala
@@ -22,21 +22,23 @@ class UserServices(client: StashClient) {
     * Gets the basic information associated with the token owner account.
     */
   def getUsers: RequestResponse[Seq[User]] = {
-    client.execute(Request("/rest/api/1.0/users", classOf[Seq[User]]))
+    client.execute(Request("/rest/api/1.0/users", classOf[Seq[User]]))()
   }
 
   /**
     * Gets the basic information associated with an account.
     */
   def getUser(username: String): RequestResponse[User] = {
-    client.execute(Request(s"/rest/api/1.0/users/$username", classOf[User]))
+    client.execute(Request(s"/rest/api/1.0/users/$username", classOf[User]))()
   }
 
   /**
     * Gets the basic information associated with an account, including their avatarUrls.
     */
   def getUserWithAvatar(username: String, size: Option[Int]): RequestResponse[User] = {
-    client.execute(Request(s"/rest/api/1.0/users/$username?avatarSize=${size.getOrElse(64)}", classOf[User]))
+    client.execute(Request(s"/rest/api/1.0/users/$username", classOf[User]))(
+      Map("avatarSize" -> size.getOrElse(64).toString)
+    )
   }
 
   /**
@@ -67,7 +69,7 @@ class UserServices(client: StashClient) {
   def deleteUserKey(keyId: Long): RequestResponse[Boolean] = {
     val url = s"/rest/ssh/1.0/keys/$keyId"
 
-    client.delete(url)
+    client.delete(url)()
   }
 
 }

--- a/src/main/scala/com/codacy/client/stash/service/WebhooksServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/WebhooksServices.scala
@@ -58,7 +58,7 @@ class WebhooksServices(client: StashClient) {
   def delete(projectKey: String, repositorySlug: String, webhookId: Long): RequestResponse[Boolean] = {
     val url = s"/rest/api/1.0/projects/$projectKey/repos/$repositorySlug/webhooks/$webhookId"
 
-    client.delete(url)
+    client.delete(url)()
   }
 
 }


### PR DESCRIPTION
- Create ssh keys endpoint was wrong
- avatar.png endpoint was wrong and not used
- We don't need to pass the parameters on the URL, we should pass them on the parameters field