### PR TITLE
feature: Add option to fetch avatars

### DIFF
--- a/src/main/scala/com/codacy/client/stash/service/PullRequestServices.scala
+++ b/src/main/scala/com/codacy/client/stash/service/PullRequestServices.scala
@@ -19,17 +19,21 @@ class PullRequestServices(client: StashClient) {
       repository: String,
       direction: String = "INCOMING",
       state: String = "OPEN",
-      order: String = "NEWEST"
+      order: String = "NEWEST",
+      includeAvatar: Boolean = false
   ): RequestResponse[Seq[PullRequest]] = {
-    val directionParam = "direction"
-    val stateParam = "state"
-    val orderParam = "order"
-    val url =
-      s"/rest/api/1.0/projects/$projectKey/repos/$repository/pull-requests"
+    val url = s"/rest/api/1.0/projects/$projectKey/repos/$repository/pull-requests"
 
-    client.executePaginated(Request(url, classOf[Seq[PullRequest]]))(
-      Map(directionParam -> direction, stateParam -> state, orderParam -> order)
-    )
+    val baseParams = Map("direction" -> direction, "state" -> state, "order" -> order)
+
+    val params =
+      if (includeAvatar) {
+        baseParams + ("avatarSize" -> "64")
+      } else {
+        baseParams
+      }
+
+    client.executePaginated(Request(url, classOf[Seq[PullRequest]]))(params)
   }
 
   /*


### PR DESCRIPTION
By passing true to this call, avatars will be fetched for all objects returned. This includes users, projects, and repositories.